### PR TITLE
Fix for #36 - Error Message Uses Incorrect Argument

### DIFF
--- a/src/main/java/phrasecount/cmd/Load.java
+++ b/src/main/java/phrasecount/cmd/Load.java
@@ -29,7 +29,7 @@ public class Load {
       File[] files = new File(args[1]).listFiles();
 
       if (files == null) {
-        System.out.println("Text file dir does not exist: " + args[0]);
+        System.out.println("Text file dir does not exist: " + args[1]);
       } else {
         for (File txtFile : files) {
           if (txtFile.getName().endsWith(".txt")) {


### PR DESCRIPTION
This addresses issue #36 where the Load.java class does a check against a value provided in args[1] and if it is null, incorrectly provides the user with an error and a reference to args[0]. This simply changes the error message to reference the correct argument.